### PR TITLE
redesign: match boondit-rhythm design language

### DIFF
--- a/creation-react/src/App.css
+++ b/creation-react/src/App.css
@@ -1,34 +1,49 @@
-/* Modern Gruvbox Dark Theme for R1 Anywhere Console */
+/* Boondit Rhythm Dark Theme for R1 Anywhere Console */
 :root {
-  /* Gruvbox Dark Colors */
-  --bg0: #1d2021;
-  --bg1: #282828;
-  --bg2: #32302f;
-  --bg3: #3c3836;
-  --bg4: #504945;
-  --bg-soft: #32302f;
-  --bg-hard: #1d2021;
+  /* Rhythm Core Colors */
+  --bg0: #111111;
+  --bg1: #1A1A1A;
+  --bg2: #1A1A1A;
+  --bg3: #1A1A1A;
+  --bg4: #292929;
+  --bg-soft: #1A1A1A;
+  --bg-hard: #111111;
   
-  --fg0: #fbf1c7;
-  --fg1: #ebdbb2;
-  --fg2: #d5c4a1;
-  --fg3: #bdae93;
-  --fg4: #a89984;
+  --fg0: #FFFFFF;
+  --fg1: #FFFFFF;
+  --fg2: #E5E5E5;
+  --fg3: #9CA3AF;
+  --fg4: #6B7280;
   
-  --red: #fb4934;
-  --green: #b8bb26;
-  --yellow: #fabd2f;
-  --blue: #83a598;
-  --purple: #d3869b;
-  --aqua: #8ec07c;
-  --orange: #fe8019;
+  --red: #FF2E88;
+  --green: #FE5F00;
+  --yellow: #FE5F00;
+  --blue: #9B2EFF;
+  --purple: #9B2EFF;
+  --aqua: #9B2EFF;
+  --orange: #FE5F00;
   
-  /* Semantic Colors */
-  --accent: var(--yellow);
-  --success: var(--green);
-  --warning: var(--orange);
-  --error: var(--red);
-  --info: var(--blue);
+  /* Rhythm Semantic Tokens */
+  --primary: #FE5F00;
+  --secondary: #FF2E88;
+  --accent: #FE5F00;
+  --accent-purple: #9B2EFF;
+  --muted: #9CA3AF;
+  --border: #292929;
+  
+  --success: var(--primary);
+  --warning: var(--primary);
+  --error: var(--secondary);
+  --info: var(--accent-purple);
+  
+  /* Gradients */
+  --gradient-pink-purple: linear-gradient(90deg, #FF1F8F 0%, #A864FF 100%);
+  --gradient-primary: linear-gradient(135deg, #FE5F00 0%, #FF2E88 100%);
+  
+  /* Brand Stripe */
+  --stripe-pink: #FF1F8F;
+  --stripe-purple: #A864FF;
+  --stripe-teal: #1F4A3F;
   
   /* Spacing */
   --space-xs: 4px;
@@ -44,9 +59,14 @@
   --radius-xl: 12px;
   
   /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.4);
-  --shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.5);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.6);
+  --shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.7);
+  
+  /* Glow Shadows */
+  --glow-primary: 0 0 12px 2px rgba(254, 95, 0, 0.6);
+  --glow-secondary: 0 0 12px 2px rgba(255, 46, 136, 0.6);
+  --glow-accent: 0 0 12px 2px rgba(155, 46, 255, 0.6);
 }
 
 * {
@@ -56,7 +76,7 @@
 }
 
 body {
-  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg0);
@@ -74,6 +94,18 @@ body {
   overflow: hidden;
 }
 
+/* Brand Stripe — 3-segment ribbon */
+.brand-stripe {
+  display: flex;
+  width: 100%;
+  height: 3px;
+  flex-shrink: 0;
+}
+
+.brand-stripe .seg-1 { background: var(--stripe-pink); flex: 1; }
+.brand-stripe .seg-2 { background: var(--stripe-purple); flex: 1; }
+.brand-stripe .seg-3 { background: var(--stripe-teal); flex: 1; }
+
 /* Status Bar */
 .status-bar {
   display: flex;
@@ -81,7 +113,7 @@ body {
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
   background: var(--bg1);
-  border-bottom: 2px solid var(--accent);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   min-height: 48px;
   gap: var(--space-sm);
@@ -101,12 +133,16 @@ body {
   gap: var(--space-xs);
   font-weight: 700;
   font-size: 16px;
-  color: var(--accent);
+  background: var(--gradient-pink-purple);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .app-title .icon {
   font-size: 18px;
-  filter: drop-shadow(0 0 4px var(--accent));
+  filter: drop-shadow(0 0 6px rgba(255, 31, 143, 0.6));
+  -webkit-text-fill-color: initial;
 }
 
 .connection-indicator {
@@ -124,13 +160,13 @@ body {
 }
 
 .connection-indicator.connected {
-  background: rgba(184, 187, 38, 0.15);
-  color: var(--success);
-  border: 1px solid var(--success);
+  background: rgba(254, 95, 0, 0.15);
+  color: var(--primary);
+  border: 1px solid var(--primary);
 }
 
 .connection-indicator.disconnected {
-  background: rgba(251, 73, 52, 0.15);
+  background: rgba(255, 46, 136, 0.15);
   color: var(--error);
   border: 1px solid var(--error);
 }
@@ -160,20 +196,20 @@ body {
   align-items: center;
   gap: var(--space-xs);
   padding: var(--space-xs) var(--space-sm);
-  background: var(--bg2);
+  background: rgba(255, 255, 255, 0.05);
   border-radius: var(--radius-md);
-  border: 1px solid var(--bg4);
+  border: 1px solid var(--border);
   font-size: 11px;
 }
 
 .device-badge {
-  color: var(--aqua);
-  border-color: var(--aqua);
+  color: var(--accent-purple);
+  border-color: var(--accent-purple);
 }
 
 .pin-badge {
-  color: var(--purple);
-  border-color: var(--purple);
+  color: var(--secondary);
+  border-color: var(--secondary);
   position: relative;
 }
 
@@ -185,9 +221,9 @@ body {
 }
 
 .device-code, .pin-code {
-  font-family: inherit;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
   font-weight: 700;
-  background: var(--bg3);
+  background: rgba(255, 255, 255, 0.05);
   padding: 2px var(--space-xs);
   border-radius: var(--radius-sm);
   border: 1px solid currentColor;
@@ -204,7 +240,7 @@ body {
   height: 20px;
   border: none;
   border-radius: 50%;
-  background: var(--bg4);
+  background: rgba(255, 255, 255, 0.05);
   color: var(--fg2);
   cursor: pointer;
   display: flex;
@@ -215,7 +251,7 @@ body {
 }
 
 .pin-action:hover {
-  background: var(--blue);
+  background: var(--accent-purple);
   color: var(--bg0);
   transform: scale(1.1);
 }
@@ -230,9 +266,9 @@ body {
   align-items: center;
   gap: var(--space-xs);
   padding: var(--space-xs) var(--space-sm);
-  background: var(--bg2);
-  color: var(--success);
-  border: 1px solid var(--success);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--primary);
+  border: 1px solid var(--primary);
   border-radius: var(--radius-md);
   font-size: 11px;
   font-weight: 600;
@@ -241,7 +277,7 @@ body {
 }
 
 .enable-pin-btn:hover {
-  background: rgba(184, 187, 38, 0.1);
+  background: rgba(254, 95, 0, 0.15);
   transform: translateY(-1px);
 }
 
@@ -249,9 +285,9 @@ body {
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  border: 1px solid var(--blue);
-  background: var(--bg2);
-  color: var(--blue);
+  border: 1px solid var(--accent-purple);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--accent-purple);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -262,7 +298,7 @@ body {
 }
 
 .refresh-btn:hover {
-  background: var(--blue);
+  background: var(--accent-purple);
   color: var(--bg0);
   transform: scale(1.05) rotate(90deg);
 }
@@ -272,7 +308,7 @@ body {
   height: 28px;
   border-radius: 50%;
   border: 1px solid var(--purple);
-  background: var(--bg2);
+  background: rgba(255, 255, 255, 0.05);
   color: var(--purple);
   cursor: pointer;
   display: flex;
@@ -294,7 +330,7 @@ body {
   height: 28px;
   border-radius: 50%;
   border: 1px solid var(--orange);
-  background: var(--bg2);
+  background: rgba(255, 255, 255, 0.05);
   color: var(--orange);
   cursor: pointer;
   display: flex;
@@ -304,8 +340,6 @@ body {
   transition: all 0.2s ease;
   flex-shrink: 0;
 }
-
-
 
 .test-btn:hover {
   background: var(--orange);
@@ -330,9 +364,10 @@ body {
 }
 
 .reconnect-btn.connected {
-  background: var(--success);
+  background: var(--primary);
   color: var(--bg0);
-  border-color: var(--success);
+  border-color: var(--primary);
+  box-shadow: var(--glow-primary);
 }
 
 .reconnect-btn.disconnected {
@@ -348,6 +383,7 @@ body {
   border-color: var(--bg4);
   cursor: not-allowed;
   animation: none;
+  box-shadow: none;
 }
 
 .reconnect-btn:hover:not(:disabled) {
@@ -356,8 +392,8 @@ body {
 }
 
 @keyframes reconnect-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(251, 73, 52, 0.4); }
-  50% { box-shadow: 0 0 0 8px rgba(251, 73, 52, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 46, 136, 0.4); }
+  50% { box-shadow: 0 0 0 8px rgba(255, 46, 136, 0); }
 }
 
 /* Main Content */
@@ -382,7 +418,7 @@ body {
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
   background: var(--bg1);
-  border-bottom: 1px solid var(--bg4);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
@@ -467,17 +503,17 @@ body {
 
 .console-entry.error {
   border-left-color: var(--error);
-  background: rgba(251, 73, 52, 0.05);
+  background: rgba(255, 46, 136, 0.05);
 }
 
 .console-entry.warn {
   border-left-color: var(--warning);
-  background: rgba(254, 128, 25, 0.05);
+  background: rgba(254, 95, 0, 0.05);
 }
 
 .console-entry.info {
   border-left-color: var(--info);
-  background: rgba(131, 165, 152, 0.05);
+  background: rgba(155, 46, 255, 0.05);
 }
 
 .entry-time {
@@ -486,7 +522,7 @@ body {
   font-weight: 500;
   min-width: 60px;
   flex-shrink: 0;
-  font-family: inherit;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
 }
 
 .level-badge {
@@ -569,8 +605,6 @@ body {
     width: 28px;
     height: 28px;
   }
-  
-
   
   .console-header {
     padding: var(--space-xs) var(--space-sm);

--- a/creation-react/src/App.jsx
+++ b/creation-react/src/App.jsx
@@ -106,6 +106,11 @@ function App() {
             onDisablePin={handleDisablePin}
             onEnablePin={handleEnablePin}
           />
+          <div className="brand-stripe">
+            <div className="seg-1"></div>
+            <div className="seg-2"></div>
+            <div className="seg-3"></div>
+          </div>
 
           {/* Main Content - Activity Log */}
           <div className="main-content">

--- a/creation-react/src/components/PerformanceMonitor.jsx
+++ b/creation-react/src/components/PerformanceMonitor.jsx
@@ -77,16 +77,17 @@ const PerformanceMonitor = () => {
         top: '10px', 
         right: '10px', 
         zIndex: 1000,
-        background: '#282828',
-        border: '1px solid #fabd2f',
+        background: '#1A1A1A',
+        border: '1px solid #FE5F00',
         borderRadius: '4px',
-        padding: '8px'
+        padding: '8px',
+        boxShadow: '0 0 12px 2px rgba(254, 95, 0, 0.4)'
       }}>
         <button 
           onClick={() => setIsVisible(true)}
           style={{
-            background: '#fabd2f',
-            color: '#282828',
+            background: '#FE5F00',
+            color: '#111111',
             border: 'none',
             padding: '4px 8px',
             borderRadius: '2px',
@@ -108,33 +109,33 @@ const PerformanceMonitor = () => {
       right: '10px',
       width: '320px',
       maxHeight: '500px',
-      background: '#282828',
-      border: '2px solid #fabd2f',
+      background: '#1A1A1A',
+      border: '2px solid #FE5F00',
       borderRadius: '8px',
       padding: '16px',
-      color: '#ebdbb2',
+      color: '#FFFFFF',
       fontSize: '12px',
-      fontFamily: 'monospace',
+      fontFamily: 'SF Mono, Monaco, Menlo, monospace',
       zIndex: 1000,
       overflow: 'auto',
-      boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
+      boxShadow: '0 4px 12px rgba(0,0,0,0.5), 0 0 12px 2px rgba(254, 95, 0, 0.3)'
     }}>
       <div style={{ 
         display: 'flex', 
         justifyContent: 'space-between', 
         alignItems: 'center',
         marginBottom: '12px',
-        borderBottom: '1px solid #504945',
+        borderBottom: '1px solid #292929',
         paddingBottom: '8px'
       }}>
-        <h3 style={{ margin: 0, color: '#fabd2f', fontSize: '14px' }}>
+        <h3 style={{ margin: 0, color: '#FE5F00', fontSize: '14px' }}>
           📊 Performance Monitor
         </h3>
         <button 
           onClick={() => setIsVisible(false)}
           style={{
-            background: '#fb4934',
-            color: '#282828',
+            background: '#FF2E88',
+            color: '#111111',
             border: 'none',
             padding: '2px 6px',
             borderRadius: '2px',
@@ -148,10 +149,10 @@ const PerformanceMonitor = () => {
 
       {/* Component Stats */}
       <div style={{ marginBottom: '12px' }}>
-        <h4 style={{ margin: '0 0 4px 0', color: '#8ec07c', fontSize: '12px' }}>
+        <h4 style={{ margin: '0 0 4px 0', color: '#FE5F00', fontSize: '12px' }}>
           Component Stats
         </h4>
-        <div style={{ background: '#3c3836', padding: '6px', borderRadius: '4px' }}>
+        <div style={{ background: 'rgba(255,255,255,0.05)', padding: '6px', borderRadius: '4px' }}>
           <div>Renders: {componentStats.renderCount}</div>
           <div>Uptime: {formatNumber(componentStats.uptime / 1000)}s</div>
           <div>Monitoring: {isMonitoring ? '✅' : '❌'}</div>
@@ -161,10 +162,10 @@ const PerformanceMonitor = () => {
       {/* Memory Stats */}
       {memoryStats && (
         <div style={{ marginBottom: '12px' }}>
-          <h4 style={{ margin: '0 0 4px 0', color: '#83a598', fontSize: '12px' }}>
+          <h4 style={{ margin: '0 0 4px 0', color: '#9B2EFF', fontSize: '12px' }}>
             Memory Usage (Client)
           </h4>
-          <div style={{ background: '#3c3836', padding: '6px', borderRadius: '4px' }}>
+          <div style={{ background: 'rgba(255,255,255,0.05)', padding: '6px', borderRadius: '4px' }}>
             <div>Heap Used: {formatBytes(memoryStats.heapUsed)}</div>
             <div>Components: {memoryStats.componentCount}</div>
             <div>Listeners: {memoryStats.listenerCount}</div>
@@ -175,10 +176,10 @@ const PerformanceMonitor = () => {
       {/* Performance Metrics */}
       {metrics && (
         <div style={{ marginBottom: '12px' }}>
-          <h4 style={{ margin: '0 0 4px 0', color: '#d3869b', fontSize: '12px' }}>
+          <h4 style={{ margin: '0 0 4px 0', color: '#9B2EFF', fontSize: '12px' }}>
             Performance Metrics
           </h4>
-          <div style={{ background: '#3c3836', padding: '6px', borderRadius: '4px' }}>
+          <div style={{ background: 'rgba(255,255,255,0.05)', padding: '6px', borderRadius: '4px' }}>
             <div>Render Time: {formatNumber(metrics.renderTime)}ms</div>
             <div>Renders: {metrics.componentRenderCount}</div>
             <div>Errors: {metrics.errorCount}</div>
@@ -190,10 +191,10 @@ const PerformanceMonitor = () => {
       {/* Server Performance Data */}
       {performanceData && (
         <div style={{ marginBottom: '12px' }}>
-          <h4 style={{ margin: '0 0 4px 0', color: '#fe8019', fontSize: '12px' }}>
+          <h4 style={{ margin: '0 0 4px 0', color: '#FE5F00', fontSize: '12px' }}>
             Server Performance
           </h4>
-          <div style={{ background: '#3c3836', padding: '6px', borderRadius: '4px' }}>
+          <div style={{ background: 'rgba(255,255,255,0.05)', padding: '6px', borderRadius: '4px' }}>
             <div>Heap Used: {formatBytes(performanceData.memory?.heapUsed || 0)}</div>
             <div>Components: {performanceData.memory?.componentCount || 0}</div>
             <div>Socket Connections: {performanceData.socketConnections || 0}</div>
@@ -205,7 +206,7 @@ const PerformanceMonitor = () => {
 
       {/* Actions */}
       <div style={{ 
-        borderTop: '1px solid #504945', 
+        borderTop: '1px solid #292929', 
         paddingTop: '8px',
         display: 'flex',
         gap: '4px',
@@ -220,8 +221,8 @@ const PerformanceMonitor = () => {
             }
           }}
           style={{
-            background: '#fb4934',
-            color: '#282828',
+            background: '#FF2E88',
+            color: '#111111',
             border: 'none',
             padding: '4px 8px',
             borderRadius: '2px',
@@ -238,8 +239,8 @@ const PerformanceMonitor = () => {
             setPerformanceData(prev => ({ ...prev, timestamp: Date.now() }));
           }}
           style={{
-            background: '#b8bb26',
-            color: '#282828',
+            background: '#FE5F00',
+            color: '#111111',
             border: 'none',
             padding: '4px 8px',
             borderRadius: '2px',
@@ -263,8 +264,8 @@ const PerformanceMonitor = () => {
             }
           }}
           style={{
-            background: '#83a598',
-            color: '#282828',
+            background: '#9B2EFF',
+            color: '#111111',
             border: 'none',
             padding: '4px 8px',
             borderRadius: '2px',
@@ -279,7 +280,7 @@ const PerformanceMonitor = () => {
       <div style={{ 
         marginTop: '8px', 
         fontSize: '10px', 
-        color: '#928374',
+        color: '#9CA3AF',
         textAlign: 'center'
       }}>
         Last updated: {new Date().toLocaleTimeString()}

--- a/creation-react/src/components/WidgetDashboard.css
+++ b/creation-react/src/components/WidgetDashboard.css
@@ -1,20 +1,34 @@
-/* WidgetDashboard.css - Minimal interface optimized for R1's 240x282 display */
+/* WidgetDashboard.css - Boondit Rhythm interface optimized for R1's 240x282 display */
 
 .widget-dashboard {
   width: 100vw;
   height: 100vh;
-  background: #000000;
+  background: #111111;
   color: #ffffff;
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   overflow: hidden;
   position: relative;
   touch-action: manipulation;
 }
 
+/* Brand stripe at top of dashboard */
+.dashboard-brand-stripe {
+  display: flex;
+  width: 100%;
+  height: 3px;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 50;
+}
+
+.dashboard-brand-stripe .seg-1 { background: #FF1F8F; flex: 1; }
+.dashboard-brand-stripe .seg-2 { background: #A864FF; flex: 1; }
+.dashboard-brand-stripe .seg-3 { background: #1F4A3F; flex: 1; }
+
 /* Dashboard container with sliding views */
 .dashboard-container {
   width: 300vw;
-  height: 100vh;
+  height: calc(100vh - 3px);
   display: flex;
   transition: transform 0.3s ease;
 }
@@ -59,7 +73,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   text-align: center;
-  color: #666666;
+  color: #9CA3AF;
   z-index: 1;
   pointer-events: none;
 }
@@ -98,22 +112,26 @@
   margin: 0;
   font-size: 18px;
   font-weight: 600;
+  background: linear-gradient(90deg, #FF1F8F 0%, #A864FF 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .back-btn {
   background: none;
   border: none;
-  color: #ffffff;
+  color: #FE5F00;
   font-size: 12px;
   cursor: pointer;
   padding: 4px 8px;
   border-radius: 4px;
-  transition: background-color 0.2s ease;
+  transition: all 0.2s ease;
 }
 
 .back-btn:hover,
 .back-btn:active {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(254, 95, 0, 0.15);
 }
 
 .console-content {
@@ -121,7 +139,7 @@
   background: rgba(255, 255, 255, 0.03);
   border-radius: 8px;
   padding: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #292929;
 }
 
 .console-info {
@@ -144,7 +162,7 @@
 }
 
 .info-label {
-  color: #999999;
+  color: #9CA3AF;
   font-weight: 500;
   flex-shrink: 0;
 }
@@ -157,17 +175,17 @@
 }
 
 .info-value.device-id {
-  font-family: 'Monaco', 'Menlo', monospace;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
   font-size: 9px;
   max-width: 120px;
 }
 
 .info-value.connected {
-  color: #34c759;
+  color: #FE5F00;
 }
 
 .info-value.disconnected {
-  color: #ff3b30;
+  color: #FF2E88;
 }
 
 .menu-header {
@@ -179,6 +197,10 @@
   font-size: 18px;
   font-weight: 600;
   text-align: center;
+  background: linear-gradient(90deg, #FF1F8F 0%, #A864FF 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .menu-items {
@@ -194,18 +216,19 @@
   gap: 12px;
   padding: 12px;
   background: rgba(255, 255, 255, 0.05);
-  border: none;
+  border: 1px solid #292929;
   border-radius: 8px;
   color: #ffffff;
   font-size: 14px;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: all 0.2s ease;
   text-align: left;
 }
 
 .menu-item:hover,
 .menu-item:active {
   background: rgba(255, 255, 255, 0.1);
+  border-color: #FE5F00;
 }
 
 .menu-icon {
@@ -232,7 +255,7 @@
   padding: 8px;
   background: rgba(255, 255, 255, 0.03);
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #292929;
 }
 
 .device-section h4,
@@ -240,7 +263,7 @@
   margin: 0 0 8px 0;
   font-size: 12px;
   font-weight: 600;
-  color: #cccccc;
+  color: #9CA3AF;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -259,7 +282,7 @@
 }
 
 .detail-label {
-  color: #999999;
+  color: #9CA3AF;
   font-weight: 500;
 }
 
@@ -269,7 +292,7 @@
 }
 
 .detail-value.device-id {
-  font-family: 'Monaco', 'Menlo', monospace;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
   font-size: 10px;
   word-break: break-all;
   text-align: right;
@@ -277,11 +300,11 @@
 }
 
 .detail-value.connected {
-  color: #34c759;
+  color: #FE5F00;
 }
 
 .detail-value.disconnected {
-  color: #ff3b30;
+  color: #FF2E88;
 }
 
 /* PIN controls */
@@ -297,7 +320,7 @@
   gap: 8px;
   padding: 8px;
   background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid #292929;
   border-radius: 4px;
   color: #ffffff;
   font-size: 11px;
@@ -307,8 +330,8 @@
 
 .pin-btn:hover,
 .pin-btn:active {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 46, 136, 0.15);
+  border-color: #FF2E88;
 }
 
 .pin-icon {
@@ -343,8 +366,9 @@
 }
 
 .indicator-dot.active {
-  background: #ffffff;
+  background: #FE5F00;
   transform: scale(1.2);
+  box-shadow: 0 0 8px 1px rgba(254, 95, 0, 0.6);
 }
 
 /* Scrollbar styling for tiny display */

--- a/creation-react/src/components/WidgetDashboard.jsx
+++ b/creation-react/src/components/WidgetDashboard.jsx
@@ -74,6 +74,12 @@ const WidgetDashboard = ({ socket, isConnected, deviceId, deviceInfo, onChangePi
       className="widget-dashboard"
       ref={dashboardRef}
     >
+      {/* Brand stripe */}
+      <div className="dashboard-brand-stripe">
+        <div className="seg-1"></div>
+        <div className="seg-2"></div>
+        <div className="seg-3"></div>
+      </div>
       <div 
         className={`dashboard-container view-${currentView}`}
         onTouchStart={onTouchStart}

--- a/creation-react/src/index.css
+++ b/creation-react/src/index.css
@@ -1,4 +1,4 @@
-/* Base styles for R1 Anywhere Console */
+/* Base styles for R1 Anywhere Console — Boondit Rhythm */
 * {
   box-sizing: border-box;
   margin: 0;
@@ -9,11 +9,11 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #1d2021;
-  color: #ebdbb2;
+  background: #111111;
+  color: #FFFFFF;
   overflow: hidden;
 }
 
@@ -23,7 +23,7 @@ html, body {
 }
 
 code {
-  font-family: inherit;
+  font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
 }
 
 /* Prevent text selection on UI elements */
@@ -37,7 +37,7 @@ button, .nav-tab, .status-bar {
 /* Focus styles */
 button:focus-visible,
 .nav-tab:focus-visible {
-  outline: 2px solid #fabd2f;
+  outline: 2px solid #FE5F00;
   outline-offset: 2px;
 }
 

--- a/creation-react/src/widgets/BaseWidget.css
+++ b/creation-react/src/widgets/BaseWidget.css
@@ -1,26 +1,26 @@
-/* BaseWidget.css - Styling for base widget component */
+/* BaseWidget.css - Boondit Rhythm styling for base widget component */
 
 .base-widget {
-  background: #1d2021;
-  border: 1px solid #3c3836;
+  background: #1A1A1A;
+  border: 1px solid #292929;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  color: #ebdbb2;
-  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  color: #FFFFFF;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   font-size: 12px;
   overflow: hidden;
   transition: all 0.2s ease;
 }
 
 .base-widget:hover {
-  border-color: #458588;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  border-color: #FE5F00;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6), 0 0 12px 2px rgba(254, 95, 0, 0.3);
 }
 
 /* Widget Header */
 .widget-header {
-  background: #282828;
-  border-bottom: 1px solid #3c3836;
+  background: #111111;
+  border-bottom: 1px solid #292929;
   padding: 8px 12px;
   display: flex;
   justify-content: space-between;
@@ -31,7 +31,7 @@
 .widget-title {
   font-weight: 600;
   font-size: 13px;
-  color: #ebdbb2;
+  color: #FFFFFF;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -56,25 +56,25 @@
 }
 
 .widget-body::-webkit-scrollbar-track {
-  background: #1d2021;
+  background: #111111;
 }
 
 .widget-body::-webkit-scrollbar-thumb {
-  background: #504945;
+  background: #292929;
   border-radius: 2px;
 }
 
 .widget-body::-webkit-scrollbar-thumb:hover {
-  background: #665c54;
+  background: #9CA3AF;
 }
 
 /* Widget Footer */
 .widget-footer {
-  background: #282828;
-  border-top: 1px solid #3c3836;
+  background: #111111;
+  border-top: 1px solid #292929;
   padding: 4px 12px;
   font-size: 10px;
-  color: #928374;
+  color: #9CA3AF;
   text-align: right;
   min-height: 20px;
   display: flex;
@@ -89,14 +89,14 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #928374;
+  color: #9CA3AF;
 }
 
 .widget-loading-spinner {
   width: 24px;
   height: 24px;
-  border: 2px solid #3c3836;
-  border-top: 2px solid #458588;
+  border: 2px solid #292929;
+  border-top: 2px solid #FE5F00;
   border-radius: 50%;
   animation: widget-spin 1s linear infinite;
   margin-bottom: 8px;
@@ -128,29 +128,30 @@
 }
 
 .widget-error-message {
-  color: #fb4934;
+  color: #FF2E88;
   font-size: 11px;
   margin-bottom: 12px;
   line-height: 1.4;
 }
 
 .widget-error-retry {
-  background: #458588;
+  background: #FE5F00;
   border: none;
   border-radius: 4px;
-  color: #ebdbb2;
+  color: #111111;
   cursor: pointer;
   font-size: 10px;
   padding: 6px 12px;
-  transition: background-color 0.2s ease;
+  transition: all 0.2s ease;
 }
 
 .widget-error-retry:hover {
-  background: #689d6a;
+  background: #FF2E88;
+  box-shadow: 0 0 12px 2px rgba(255, 46, 136, 0.5);
 }
 
 .widget-error-retry:active {
-  background: #427b58;
+  background: #9B2EFF;
 }
 
 /* Responsive adjustments for small widgets */
@@ -183,45 +184,45 @@
   font-size: 9px;
 }
 
-/* Theme variations */
+/* Theme variations — dark-only rhythm theme */
 .base-widget.theme-light {
-  background: #fbf1c7;
-  border-color: #d5c4a1;
-  color: #3c3836;
+  background: #1A1A1A;
+  border-color: #292929;
+  color: #FFFFFF;
 }
 
 .base-widget.theme-light .widget-header {
-  background: #f2e5bc;
-  border-bottom-color: #d5c4a1;
+  background: #111111;
+  border-bottom-color: #292929;
 }
 
 .base-widget.theme-light .widget-title {
-  color: #3c3836;
+  color: #FFFFFF;
 }
 
 .base-widget.theme-light .widget-footer {
-  background: #f2e5bc;
-  border-top-color: #d5c4a1;
-  color: #7c6f64;
+  background: #111111;
+  border-top-color: #292929;
+  color: #9CA3AF;
 }
 
 .base-widget.theme-light .widget-loading {
-  color: #7c6f64;
+  color: #9CA3AF;
 }
 
 .base-widget.theme-light .widget-loading-spinner {
-  border-color: #d5c4a1;
-  border-top-color: #076678;
+  border-color: #292929;
+  border-top-color: #FE5F00;
 }
 
 .base-widget.theme-light .widget-error-message {
-  color: #cc241d;
+  color: #FF2E88;
 }
 
 .base-widget.theme-light .widget-error-retry {
-  background: #076678;
+  background: #FE5F00;
 }
 
 .base-widget.theme-light .widget-error-retry:hover {
-  background: #427b58;
+  background: #FF2E88;
 }

--- a/creation-react/src/widgets/WidgetRenderer.css
+++ b/creation-react/src/widgets/WidgetRenderer.css
@@ -1,4 +1,4 @@
-/* WidgetRenderer.css - Styling for widget renderer container */
+/* WidgetRenderer.css - Boondit Rhythm styling for widget renderer container */
 
 .widget-renderer {
   position: relative;

--- a/creation-react/src/widgets/WidgetRenderer.jsx
+++ b/creation-react/src/widgets/WidgetRenderer.jsx
@@ -286,10 +286,10 @@ class WidgetRenderer extends Component {
             <div style={{ fontSize: '14px', marginBottom: '8px' }}>
               {widgetId}
             </div>
-            <div style={{ fontSize: '10px', color: '#928374' }}>
+            <div style={{ fontSize: '10px', color: '#9CA3AF' }}>
               Widget ID: {this.props.instanceId}
             </div>
-            <div style={{ fontSize: '10px', color: '#928374', marginTop: '4px' }}>
+            <div style={{ fontSize: '10px', color: '#9CA3AF', marginTop: '4px' }}>
               {JSON.stringify(this.props.config, null, 2)}
             </div>
           </div>

--- a/r1-control-panel/src/App.css
+++ b/r1-control-panel/src/App.css
@@ -1,4 +1,4 @@
-/* App-specific Gruvbox styles */
+/* App-specific Rhythm styles */
 .App {
   min-height: 100vh;
   background: var(--bg0);
@@ -9,14 +9,14 @@
   margin-top: 20px;
 }
 
-/* Override any remaining non-Gruvbox styles */
+/* Override any remaining non-rhythm styles */
 .App * {
   color: inherit;
 }
 
 .App .card {
   background: var(--bg1) !important;
-  border: 1px solid var(--bg3) !important;
+  border: 1px solid var(--border) !important;
   color: var(--fg1) !important;
 }
 
@@ -25,19 +25,19 @@
 .App .form-textarea {
   background: var(--bg0) !important;
   color: var(--fg1) !important;
-  border: 1px solid var(--bg3) !important;
+  border: 1px solid var(--border) !important;
 }
 
 .App .form-input:focus,
 .App .form-select:focus,
 .App .form-textarea:focus {
-  border-color: var(--yellow) !important;
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2) !important;
+  border-color: var(--primary) !important;
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4) !important;
 }
 
-/* Ensure buttons follow Gruvbox theme */
+/* Ensure buttons follow rhythm theme */
 .App .btn {
-  font-family: 'JetBrains Mono', monospace !important;
+  font-family: inherit !important;
   font-weight: bold !important;
 }
 
@@ -51,27 +51,28 @@
 
 .template-card {
   padding: 15px;
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
   background: var(--bg1);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .template-card:hover {
-  border-color: var(--yellow);
+  border-color: var(--primary);
   background: var(--bg2);
+  box-shadow: var(--glow);
 }
 
 .template-card.selected {
-  border-color: var(--yellow);
+  border-color: var(--primary);
   background: var(--bg2);
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.3);
 }
 
 .template-card h4 {
   margin: 0 0 8px 0;
-  color: var(--yellow);
+  color: var(--primary);
   font-size: 1.1em;
 }
 
@@ -89,8 +90,8 @@
 }
 
 .template-meta .category {
-  background: var(--blue);
-  color: var(--bg0);
+  background: var(--gradient);
+  color: #FFFFFF;
   padding: 2px 6px;
   border-radius: 3px;
   text-transform: uppercase;
@@ -98,7 +99,7 @@
 
 .template-meta .tools-count {
   background: var(--green);
-  color: var(--bg0);
+  color: #FFFFFF;
   padding: 2px 6px;
   border-radius: 3px;
 }
@@ -106,10 +107,10 @@
 .selected-template-notice {
   margin: 10px 0;
   padding: 10px;
-  background: rgba(250, 189, 47, 0.1);
-  border: 1px solid var(--yellow);
+  background: rgba(254, 95, 0, 0.1);
+  border: 1px solid var(--primary);
   border-radius: 4px;
-  color: var(--yellow);
+  color: var(--primary);
   font-size: 0.9em;
 }
 
@@ -122,15 +123,15 @@
 }
 
 .connection-test-result.success {
-  background: rgba(184, 187, 38, 0.1);
+  background: rgba(63, 185, 80, 0.1);
   border: 1px solid var(--green);
   color: var(--green);
 }
 
 .connection-test-result.error {
-  background: rgba(251, 73, 52, 0.1);
-  border: 1px solid var(--red);
-  color: var(--red);
+  background: rgba(255, 46, 136, 0.1);
+  border: 1px solid var(--secondary);
+  color: var(--secondary);
 }
 
 /* Capabilities grid */
@@ -143,8 +144,8 @@
 
 .capability-item {
   padding: 15px;
-  border: 1px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   background: var(--bg1);
 }
 
@@ -165,7 +166,7 @@
 .capability-config {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid var(--bg3);
+  border-top: 1px solid var(--border);
 }
 
 .capability-config label {
@@ -185,8 +186,8 @@
   margin-top: 15px;
   padding: 15px;
   background: var(--bg1);
-  border: 1px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
 /* Modal improvements */
@@ -199,7 +200,7 @@
 .form-section {
   margin-bottom: 25px;
   padding-bottom: 20px;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
 }
 
 .form-section:last-child {
@@ -208,12 +209,12 @@
 
 .form-section h3 {
   margin: 0 0 15px 0;
-  color: var(--yellow);
+  color: var(--primary);
   font-size: 1.2em;
 }
 
 .form-help {
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 0.85em;
   margin-top: 4px;
   line-height: 1.4;
@@ -233,8 +234,8 @@
 
 .coming-soon-badge {
   font-size: 0.7em;
-  background: var(--orange);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   padding: 2px 6px;
   border-radius: 10px;
   margin-left: 8px;
@@ -247,7 +248,7 @@
 .global-footer {
   margin-top: 40px;
   padding-top: 20px;
-  border-top: 1px solid var(--bg3);
+  border-top: 1px solid var(--border);
 }
 
 .global-footer .card {
@@ -255,13 +256,13 @@
 }
 
 .global-footer h2 {
-  color: var(--aqua);
+  color: var(--accent);
   font-size: 1.2em;
   margin-bottom: 10px;
 }
 
 .global-footer p {
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 0.9em;
   margin-bottom: 20px;
 }
@@ -274,19 +275,19 @@
 }
 
 .app-card {
-  background: linear-gradient(135deg, var(--bg0) 0%, var(--bg1) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px;
   text-align: center;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .app-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
-  border-color: var(--blue);
+  box-shadow: var(--glow-purple);
+  border-color: var(--accent);
 }
 
 .app-header {
@@ -300,19 +301,19 @@
 .app-icon {
   width: 48px;
   height: 48px;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  border-radius: var(--radius);
+  box-shadow: none;
 }
 
 .app-info h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin: 0 0 5px 0;
   font-size: 1.2em;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
 }
 
 .app-info p {
-  color: var(--fg3);
+  color: var(--muted);
   margin: 0;
   font-size: 0.9em;
 }
@@ -323,8 +324,8 @@
   justify-content: center;
   padding: 15px;
   background: var(--bg0);
-  border-radius: 8px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .app-actions {
@@ -332,20 +333,20 @@
 }
 
 .app-actions .btn {
-  background: var(--green);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   padding: 12px 24px;
   font-size: 14px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .app-actions .btn:hover {
-  background: var(--green-dim);
+  filter: brightness(1.1);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--glow);
 }
 
 /* Mobile responsiveness */
@@ -393,28 +394,28 @@
 .api-docs-header {
   margin-bottom: 30px;
   padding-bottom: 20px;
-  border-bottom: 2px solid var(--bg3);
+  border-bottom: 2px solid var(--border);
 }
 
 .api-docs-header h2 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
   font-size: 2em;
-  text-shadow: 0 0 15px rgba(250, 189, 47, 0.4);
+  text-shadow: 0 0 15px rgba(254, 95, 0, 0.4);
 }
 
 .api-base-url {
   background: var(--bg0);
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   margin-bottom: 15px;
-  font-family: 'Monaco', monospace;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  font-family: 'JetBrains Mono', monospace;
+  box-shadow: none;
 }
 
 .api-base-url strong {
-  color: var(--aqua);
+  color: var(--accent);
   display: block;
   margin-bottom: 8px;
   font-size: 14px;
@@ -429,20 +430,20 @@
   border-radius: 4px;
   font-size: 16px;
   font-weight: bold;
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
   word-break: break-all;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .api-auth-notice {
-  background: linear-gradient(135deg, var(--purple-dim), var(--purple));
-  color: var(--bg0);
+  background: var(--gradient-diag);
+  color: #FFFFFF;
   padding: 12px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   margin-bottom: 20px;
-  border-left: 4px solid var(--purple);
+  border-left: 4px solid var(--accent);
   font-weight: bold;
-  box-shadow: 0 2px 8px rgba(211, 134, 155, 0.3);
+  box-shadow: var(--glow-purple);
 }
 
 .api-docs-header p {
@@ -457,28 +458,28 @@
 }
 
 .api-endpoints h3 {
-  color: var(--blue);
+  color: var(--accent);
   margin-bottom: 20px;
   font-size: 1.5em;
-  text-shadow: 0 0 10px rgba(131, 165, 152, 0.3);
-  border-bottom: 1px solid var(--bg3);
+  text-shadow: 0 0 12px rgba(155, 46, 255, 0.3);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 10px;
 }
 
 .endpoint-card {
-  background: linear-gradient(135deg, var(--bg0) 0%, var(--bg1) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 10px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px;
   margin-bottom: 20px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
   transition: all 0.3s ease;
 }
 
 .endpoint-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
-  border-color: var(--bg4);
+  box-shadow: var(--glow-purple);
+  border-color: var(--accent);
 }
 
 .endpoint-header {
@@ -496,29 +497,29 @@
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .method-badge.get {
   background: linear-gradient(135deg, var(--green-dim), var(--green));
-  color: var(--bg0);
+  color: #FFFFFF;
 }
 
 .method-badge.post {
-  background: linear-gradient(135deg, var(--blue-dim), var(--blue));
-  color: var(--bg0);
+  background: var(--gradient);
+  color: #FFFFFF;
 }
 
 .endpoint-path {
-  background: var(--bg1);
-  color: var(--yellow);
+  background: var(--bg0);
+  color: var(--primary);
   padding: 8px 12px;
-  border-radius: 6px;
-  font-family: 'Monaco', monospace;
+  border-radius: var(--radius-sm);
+  font-family: 'JetBrains Mono', monospace;
   font-size: 14px;
   font-weight: bold;
-  border: 1px solid var(--bg3);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border);
+  box-shadow: none;
 }
 
 .endpoint-description {
@@ -530,20 +531,20 @@
 
 .endpoint-example {
   background: var(--bg0);
-  border: 1px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   padding: 15px;
   margin-top: 15px;
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .endpoint-example h4 {
-  color: var(--aqua);
+  color: var(--accent);
   margin-bottom: 10px;
   font-size: 14px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  text-shadow: 0 0 8px rgba(142, 192, 124, 0.3);
+  text-shadow: 0 0 8px rgba(155, 46, 255, 0.3);
 }
 
 .code-example {
@@ -551,30 +552,30 @@
   color: var(--fg1);
   padding: 12px;
   border-radius: 4px;
-  font-family: 'Monaco', 'Menlo', monospace;
+  font-family: 'JetBrains Mono', 'Menlo', monospace;
   font-size: 13px;
   line-height: 1.4;
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
   overflow-x: auto;
   white-space: pre-wrap;
   word-break: break-all;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .api-features {
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 10px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px;
   margin-bottom: 25px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .api-features h3 {
-  color: var(--purple);
+  color: var(--accent);
   margin-bottom: 15px;
   font-size: 1.4em;
-  text-shadow: 0 0 10px rgba(211, 134, 155, 0.3);
+  text-shadow: 0 0 12px rgba(155, 46, 255, 0.3);
 }
 
 .api-features ul {
@@ -585,7 +586,7 @@
 
 .api-features li {
   padding: 8px 0;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
   color: var(--fg2);
   font-size: 15px;
   line-height: 1.4;
@@ -596,23 +597,23 @@
 }
 
 .api-features li strong {
-  color: var(--aqua);
-  text-shadow: 0 0 8px rgba(142, 192, 124, 0.3);
+  color: var(--accent);
+  text-shadow: 0 0 8px rgba(155, 46, 255, 0.3);
 }
 
 .api-notes {
-  background: linear-gradient(135deg, var(--bg0) 0%, var(--bg1) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 10px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .api-notes h3 {
-  color: var(--orange);
+  color: var(--primary);
   margin-bottom: 15px;
   font-size: 1.4em;
-  text-shadow: 0 0 10px rgba(254, 128, 25, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
 }
 
 .api-notes ul {
@@ -623,7 +624,7 @@
 
 .api-notes li {
   padding: 8px 0;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
   color: var(--fg2);
   font-size: 14px;
   line-height: 1.5;
@@ -634,18 +635,18 @@
 }
 
 .api-notes li strong {
-  color: var(--yellow);
-  text-shadow: 0 0 8px rgba(250, 189, 47, 0.3);
+  color: var(--primary);
+  text-shadow: 0 0 8px rgba(254, 95, 0, 0.3);
 }
 
 .api-notes code {
-  background: var(--bg1);
+  background: var(--bg0);
   color: var(--green);
   padding: 2px 6px;
   border-radius: 3px;
-  font-family: 'Monaco', monospace;
+  font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
 }
 
 /* Mobile responsiveness for API docs */
@@ -678,10 +679,10 @@
 .phone-link .opt-in-section {
   margin-bottom: 30px;
   padding: 20px;
-  background: linear-gradient(135deg, var(--bg2) 0%, var(--bg1) 100%);
-  border-radius: 12px;
-  border: 2px solid var(--bg3);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  background: var(--bg1);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: none;
 }
 
 .phone-link .consent-notice {
@@ -689,11 +690,11 @@
 }
 
 .phone-link .consent-notice h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
   font-size: 1.3em;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
-  border-bottom: 1px solid var(--bg3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 8px;
 }
 
@@ -706,17 +707,17 @@
 
 .phone-link .consent-details {
   background: var(--bg0);
-  border: 1px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   margin-bottom: 15px;
 }
 
 .phone-link .consent-details strong {
-  color: var(--aqua);
+  color: var(--accent);
   display: block;
   margin-bottom: 10px;
-  text-shadow: 0 0 8px rgba(142, 192, 124, 0.3);
+  text-shadow: 0 0 8px rgba(155, 46, 255, 0.3);
 }
 
 .phone-link .consent-details ul {
@@ -735,7 +736,7 @@
 }
 
 .phone-link .privacy-links a {
-  color: var(--blue);
+  color: var(--accent);
   text-decoration: none;
   font-size: 14px;
   font-weight: bold;
@@ -744,14 +745,14 @@
 }
 
 .phone-link .privacy-links a:hover {
-  color: var(--blue-dim);
+  color: var(--primary);
   text-decoration: underline;
 }
 
 .phone-link .consent-expanded {
   background: var(--bg0);
-  border: 1px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   margin-top: 15px;
   animation: slideDown 0.3s ease-out;
@@ -769,10 +770,10 @@
 }
 
 .phone-link .consent-expanded h4 {
-  color: var(--purple);
+  color: var(--accent);
   margin-bottom: 10px;
   font-size: 1.1em;
-  text-shadow: 0 0 8px rgba(211, 134, 155, 0.3);
+  text-shadow: 0 0 8px rgba(155, 46, 255, 0.3);
 }
 
 .phone-link .consent-expanded p {
@@ -782,17 +783,17 @@
 }
 
 .phone-link .consent-expanded strong {
-  color: var(--orange);
-  text-shadow: 0 0 8px rgba(254, 128, 25, 0.3);
+  color: var(--primary);
+  text-shadow: 0 0 8px rgba(254, 95, 0, 0.3);
 }
 
 .phone-link .consent-checkbox {
   margin-bottom: 20px;
   padding: 15px;
   background: var(--bg0);
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: none;
 }
 
 .phone-link .checkbox-label {
@@ -809,7 +810,7 @@
   width: 18px;
   height: 18px;
   margin-top: 2px;
-  accent-color: var(--green);
+  accent-color: var(--primary);
   cursor: pointer;
 }
 
@@ -818,7 +819,7 @@
   width: 18px;
   height: 18px;
   background: var(--bg0);
-  border: 2px solid var(--bg3);
+  border: 2px solid var(--border);
   border-radius: 3px;
   position: relative;
   margin-right: 10px;
@@ -826,7 +827,7 @@
 }
 
 .phone-link .consent-required {
-  color: var(--red);
+  color: var(--secondary);
   font-size: 12px;
   font-weight: bold;
   margin-top: 5px;
@@ -842,16 +843,16 @@
 .phone-link .opt-out-info {
   margin-top: 20px;
   padding: 15px;
-  background: rgba(251, 73, 52, 0.1);
-  border: 1px solid var(--red);
-  border-radius: 8px;
+  background: rgba(255, 46, 136, 0.1);
+  border: 1px solid var(--secondary);
+  border-radius: var(--radius);
 }
 
 .phone-link .opt-out-info h4 {
-  color: var(--red);
+  color: var(--secondary);
   margin-bottom: 10px;
   font-size: 1.1em;
-  text-shadow: 0 0 8px rgba(251, 73, 52, 0.3);
+  text-shadow: 0 0 8px rgba(255, 46, 136, 0.3);
 }
 
 .phone-link .opt-out-info p {
@@ -873,12 +874,12 @@
 
 .phone-link .opt-out-info code {
   background: var(--bg0);
-  color: var(--red);
+  color: var(--secondary);
   padding: 2px 4px;
   border-radius: 3px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
 }
 
 .phone-link .link-form,
@@ -886,8 +887,8 @@
   margin-bottom: 30px;
   padding: 20px;
   background: var(--bg2);
-  border-radius: 8px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .phone-link .form-group {
@@ -897,7 +898,7 @@
 .phone-link .form-group label {
   display: block;
   margin-bottom: 5px;
-  color: var(--aqua);
+  color: var(--accent);
   font-weight: bold;
 }
 
@@ -905,22 +906,22 @@
   width: 100%;
   padding: 10px;
   background: var(--bg0);
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--fg1);
   font-family: 'JetBrains Mono', monospace;
 }
 
 .phone-link .form-group input:focus {
-  border-color: var(--yellow);
+  border-color: var(--primary);
   outline: none;
-  box-shadow: 0 0 0 2px rgba(250, 189, 47, 0.2);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4);
 }
 
 .phone-link .form-group small {
   display: block;
   margin-top: 5px;
-  color: var(--fg4);
+  color: var(--muted);
   font-size: 12px;
 }
 
@@ -936,36 +937,39 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: inherit;
   font-weight: bold;
   transition: all 0.2s;
 }
 
 .phone-link .btn-primary {
-  background: var(--green);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
 }
 
 .phone-link .btn-primary:hover:not(:disabled) {
-  background: var(--green-dim);
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
 }
 
 .phone-link .btn-secondary {
-  background: var(--bg3);
+  background: var(--bg2);
   color: var(--fg1);
+  border: 1px solid var(--border);
 }
 
 .phone-link .btn-secondary:hover {
-  background: var(--bg4);
+  background: var(--border);
 }
 
 .phone-link .btn-danger {
-  background: var(--red);
-  color: var(--fg0);
+  background: var(--secondary);
+  color: #FFFFFF;
 }
 
 .phone-link .btn-danger:hover {
   background: var(--red-dim);
+  box-shadow: var(--glow-pink);
 }
 
 .phone-link .btn-small {
@@ -981,15 +985,15 @@
 }
 
 .phone-link .message.success {
-  background: rgba(184, 187, 38, 0.2);
+  background: rgba(63, 185, 80, 0.2);
   border: 1px solid var(--green);
   color: var(--green);
 }
 
 .phone-link .message.error {
-  background: rgba(251, 73, 52, 0.2);
-  border: 1px solid var(--red);
-  color: var(--red);
+  background: rgba(255, 46, 136, 0.2);
+  border: 1px solid var(--secondary);
+  color: var(--secondary);
 }
 
 .phone-link .linked-phones {
@@ -997,7 +1001,7 @@
 }
 
 .phone-link .linked-phones h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
 }
 
@@ -1014,7 +1018,7 @@
   padding: 10px;
   background: var(--bg2);
   border-radius: 4px;
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
 }
 
 .phone-link .phone-number {
@@ -1031,12 +1035,12 @@
   margin-top: 30px;
   padding: 20px;
   background: var(--bg2);
-  border-radius: 8px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .phone-link .instructions h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
 }
 
@@ -1072,16 +1076,16 @@
 
 .phone-link .confirm-content {
   background: var(--bg1);
-  border: 2px solid var(--yellow);
-  border-radius: 8px;
+  border: 2px solid var(--primary);
+  border-radius: var(--radius);
   padding: 20px;
   max-width: 400px;
   width: 90%;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--glow);
 }
 
 .phone-link .confirm-content h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-top: 0;
   margin-bottom: 15px;
   text-align: center;
@@ -1110,7 +1114,7 @@
 }
 
 .template-required {
-  color: var(--yellow);
+  color: var(--primary);
 }
 
 /* Modal Styles */
@@ -1130,13 +1134,13 @@
 
 .modal-content {
   background: var(--bg1);
-  border: 2px solid var(--bg3);
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   max-width: 600px;
   width: 100%;
   max-height: 90vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 40px 4px rgba(0, 0, 0, 0.6);
 }
 
 .modal-content.large-modal {
@@ -1148,23 +1152,23 @@
   justify-content: space-between;
   align-items: center;
   padding: 20px 24px;
-  border-bottom: 1px solid var(--bg3);
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg1);
 }
 
 .modal-title {
   font-size: 1.4em;
   font-weight: bold;
-  color: var(--yellow);
+  color: var(--primary);
   margin: 0;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
 }
 
 .modal-close {
   background: none;
   border: none;
   font-size: 24px;
-  color: var(--fg3);
+  color: var(--muted);
   cursor: pointer;
   padding: 4px;
   border-radius: 4px;
@@ -1172,14 +1176,14 @@
 }
 
 .modal-close:hover {
-  background: var(--bg3);
+  background: var(--bg2);
   color: var(--fg1);
 }
 
 /* Form Styles */
 .form-section {
   padding: 20px 24px;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
 }
 
 .form-section:last-child {
@@ -1187,11 +1191,11 @@
 }
 
 .form-section h3 {
-  color: var(--blue);
+  color: var(--accent);
   margin: 0 0 15px 0;
   font-size: 1.2em;
-  text-shadow: 0 0 8px rgba(131, 165, 152, 0.3);
-  border-bottom: 1px solid var(--bg3);
+  text-shadow: 0 0 8px rgba(155, 46, 255, 0.3);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 8px;
 }
 
@@ -1202,7 +1206,7 @@
 .form-label {
   display: block;
   margin-bottom: 6px;
-  color: var(--aqua);
+  color: var(--accent);
   font-weight: bold;
   font-size: 14px;
   text-transform: uppercase;
@@ -1215,26 +1219,26 @@
   width: 100%;
   padding: 12px;
   background: var(--bg0);
-  border: 2px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   color: var(--fg1);
   font-family: 'JetBrains Mono', monospace;
   font-size: 14px;
   transition: all 0.2s;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .form-input:focus,
 .form-textarea:focus,
 .form-select:focus {
-  border-color: var(--yellow);
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2), inset 0 1px 3px rgba(0, 0, 0, 0.2);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4);
   outline: none;
 }
 
 .form-input.error {
-  border-color: var(--red);
-  box-shadow: 0 0 0 3px rgba(251, 73, 52, 0.2), inset 0 1px 3px rgba(0, 0, 0, 0.2);
+  border-color: var(--secondary);
+  box-shadow: 0 0 0 2px rgba(255, 46, 136, 0.4);
 }
 
 .form-textarea {
@@ -1250,7 +1254,7 @@
 .form-help {
   display: block;
   margin-top: 6px;
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -1265,15 +1269,15 @@
 
 .capability-item {
   background: var(--bg0);
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   transition: all 0.2s;
 }
 
 .capability-item:hover {
-  border-color: var(--blue);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  border-color: var(--accent);
+  box-shadow: var(--glow-purple);
 }
 
 .capability-label {
@@ -1288,13 +1292,13 @@
 .capability-label input[type="checkbox"] {
   width: 16px;
   height: 16px;
-  accent-color: var(--green);
+  accent-color: var(--primary);
 }
 
 .capability-config {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid var(--bg3);
+  border-top: 1px solid var(--border);
 }
 
 .capability-config label {
@@ -1310,8 +1314,8 @@
   margin-top: 15px;
   padding: 15px;
   background: var(--bg0);
-  border: 1px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
 .advanced-config .form-group {
@@ -1328,11 +1332,11 @@
   align-items: center;
   justify-content: center;
   padding: 10px 20px;
-  background: var(--bg3);
+  background: var(--bg2);
   color: var(--fg1);
-  border: 2px solid var(--bg3);
-  border-radius: 6px;
-  font-family: 'JetBrains Mono', monospace;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
   font-weight: bold;
   font-size: 14px;
   text-transform: uppercase;
@@ -1343,29 +1347,31 @@
 }
 
 .btn:hover:not(:disabled) {
-  background: var(--bg4);
-  border-color: var(--bg4);
+  background: var(--border);
+  border-color: var(--accent);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--glow-purple);
 }
 
 .btn:active {
   transform: translateY(0);
+  text-shadow: -1px 0 var(--secondary), 1px 0 var(--accent);
 }
 
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
+  box-shadow: none;
 }
 
 .btn.btn-secondary {
-  background: var(--bg2);
-  border-color: var(--bg3);
+  background: transparent;
+  border-color: var(--border);
 }
 
 .btn.btn-secondary:hover:not(:disabled) {
-  background: var(--bg3);
+  background: var(--bg1);
 }
 
 .btn.small {
@@ -1399,17 +1405,17 @@
 .empty-state {
   text-align: center;
   padding: 40px 20px;
-  background: linear-gradient(135deg, var(--bg0) 0%, var(--bg1) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   margin-top: 20px;
 }
 
 .empty-state h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
   font-size: 1.4em;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
 }
 
 .empty-state p {
@@ -1424,15 +1430,15 @@
   align-items: center;
   justify-content: center;
   padding: 40px;
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 16px;
 }
 
 .loading {
   width: 20px;
   height: 20px;
-  border: 2px solid var(--bg3);
-  border-top: 2px solid var(--yellow);
+  border: 2px solid var(--border);
+  border-top: 2px solid var(--primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin-right: 10px;
@@ -1486,15 +1492,15 @@
 }
 
 .connection-test-result.success {
-  background: rgba(152, 195, 121, 0.1);
+  background: rgba(63, 185, 80, 0.1);
   border-color: var(--green);
   color: var(--green);
 }
 
 .connection-test-result.error {
-  background: rgba(251, 73, 52, 0.1);
-  border-color: #ff6b6b;
-  color: #ff6b6b;
+  background: rgba(255, 46, 136, 0.1);
+  border-color: var(--secondary);
+  color: var(--secondary);
 }
 
 /* Speech Test Styles */
@@ -1515,7 +1521,7 @@
   display: block;
   margin-bottom: 8px;
   font-weight: bold;
-  color: var(--aqua);
+  color: var(--accent);
 }
 
 .preset-grid {
@@ -1527,7 +1533,7 @@
 .preset-btn {
   padding: 8px 12px;
   background: var(--bg2);
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
   color: var(--fg2);
   border-radius: 4px;
   cursor: pointer;
@@ -1537,9 +1543,9 @@
 }
 
 .preset-btn:hover {
-  background: var(--bg3);
-  border-color: var(--yellow);
-  color: var(--yellow);
+  background: var(--border);
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 .speech-controls {
@@ -1566,37 +1572,38 @@
 }
 
 .primary-btn {
-  background: var(--green);
-  color: var(--bg0);
-  border: 2px solid var(--green);
+  background: var(--primary);
+  color: #FFFFFF;
+  border: 1px solid var(--primary);
   padding: 12px 24px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: inherit;
   font-size: 14px;
   font-weight: bold;
   transition: all 0.2s ease;
 }
 
 .primary-btn:hover:not(:disabled) {
-  background: var(--green-dim);
+  filter: brightness(1.1);
   transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--glow);
 }
 
 .primary-btn:disabled {
-  background: var(--bg3);
-  border-color: var(--bg4);
-  color: var(--fg4);
+  background: var(--border);
+  border-color: var(--border);
+  color: var(--muted);
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+  filter: none;
 }
 
 .error-message {
-  background: rgba(251, 73, 52, 0.1);
-  border: 1px solid var(--red);
-  color: var(--red);
+  background: rgba(255, 46, 136, 0.1);
+  border: 1px solid var(--secondary);
+  color: var(--secondary);
   padding: 10px;
   border-radius: 4px;
   margin: 10px 0;
@@ -1604,7 +1611,7 @@
 }
 
 .success-message {
-  background: rgba(184, 187, 38, 0.1);
+  background: rgba(63, 185, 80, 0.1);
   border: 1px solid var(--green);
   color: var(--green);
   padding: 10px;
@@ -1616,11 +1623,11 @@
 .info-section {
   margin-top: 30px;
   padding-top: 20px;
-  border-top: 1px solid var(--bg3);
+  border-top: 1px solid var(--border);
 }
 
 .info-section h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-top: 20px;
   margin-bottom: 10px;
 }
@@ -1636,7 +1643,7 @@
 
 .code-example {
   background: var(--bg0);
-  border: 1px solid var(--bg3);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 15px;
   margin: 10px 0;

--- a/r1-control-panel/src/components/AddServerModal.js
+++ b/r1-control-panel/src/components/AddServerModal.js
@@ -380,7 +380,7 @@ const AddServerModal = ({ onAdd, onClose }) => {
                   <small className="form-help">
                     Full URL to the MCP server endpoint supporting HTTP transport
                     {formData.url && !validateUrl(formData.url) && (
-                      <span style={{ color: '#ff6b6b' }}> • Invalid URL format</span>
+                      <span style={{ color: '#FF2E88' }}> • Invalid URL format</span>
                     )}
                   </small>
                 </div>

--- a/r1-control-panel/src/components/DeviceLogin.js
+++ b/r1-control-panel/src/components/DeviceLogin.js
@@ -94,11 +94,11 @@ const DeviceLogin = ({
                             url: "https://r1a.boondit.site/creation",
                             description: "Use R1 anywhere",
                             iconUrl: "https://boondit.site/icons/r1a.png",
-                            themeColor: "#ff61f2"
+                            themeColor: "#FE5F00"
                         })}
                         size={400}
-                        fgColor="#ebdbb2"
-                        bgColor="#282828"
+                        fgColor="#FFFFFF"
+                        bgColor="#111111"
                         level="M"
                     />
                 </div>

--- a/r1-control-panel/src/components/LogsModal.js
+++ b/r1-control-panel/src/components/LogsModal.js
@@ -111,7 +111,7 @@ const LogsModal = ({ deviceId, pinCode, onClose }) => {
               Loading logs...
             </div>
           ) : logs.length === 0 ? (
-            <div style={{ textAlign: 'center', padding: '20px', color: '#666' }}>
+            <div style={{ textAlign: 'center', padding: '20px', color: '#9CA3AF' }}>
               No logs available
             </div>
           ) : (

--- a/r1-control-panel/src/components/MCPServerCard.js
+++ b/r1-control-panel/src/components/MCPServerCard.js
@@ -46,8 +46,8 @@ const MCPServerCard = ({ server, deviceId, pinCode, onToggle, onDelete }) => {
             toolsHtml += `
               <li style="margin-bottom: 10px;">
                 <strong>${tool.tool_name}</strong><br>
-                <small style="color: #666;">${tool.tool_description || 'No description'}</small><br>
-                <small style="color: #999;">Used ${tool.usage_count || 0} times</small>
+                <small style="color: #9CA3AF;">${tool.tool_description || 'No description'}</small><br>
+                <small style="color: #6B7280;">Used ${tool.usage_count || 0} times</small>
               </li>
             `;
           });
@@ -60,9 +60,9 @@ const MCPServerCard = ({ server, deviceId, pinCode, onToggle, onDelete }) => {
             <head>
               <title>MCP Tools - ${server.name}</title>
               <style>
-                body { font-family: Arial, sans-serif; padding: 20px; background: #282828; color: #ebdbb2; }
+                body { font-family: Arial, sans-serif; padding: 20px; background: #111111; color: #FFFFFF; }
                 ul { list-style-type: none; padding: 0; }
-                li { padding: 10px; border: 1px solid #504945; margin-bottom: 5px; border-radius: 4px; background: #3c3836; }
+                li { padding: 10px; border: 1px solid #292929; margin-bottom: 5px; border-radius: 4px; background: #1A1A1A; }
               </style>
             </head>
             <body>${toolsHtml}</body>
@@ -143,7 +143,7 @@ const MCPServerCard = ({ server, deviceId, pinCode, onToggle, onDelete }) => {
             </div>
           ))}
           {server.tools.length > 3 && (
-            <div style={{ fontSize: '0.8em', color: '#666', textAlign: 'center', marginTop: '5px' }}>
+            <div style={{ fontSize: '0.8em', color: '#9CA3AF', textAlign: 'center', marginTop: '5px' }}>
               +{server.tools.length - 3} more tools
             </div>
           )}

--- a/r1-control-panel/src/components/WidgetManager.css
+++ b/r1-control-panel/src/components/WidgetManager.css
@@ -1,4 +1,4 @@
-/* WidgetManager.css - Styling for widget management interface */
+/* WidgetManager.css - Styling for widget management interface (Rhythm dark theme) */
 
 .widget-manager {
   padding: 20px;
@@ -12,36 +12,43 @@
   align-items: flex-start;
   margin-bottom: 30px;
   padding-bottom: 20px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border);
 }
 
 .widget-manager-header h2 {
   margin: 0 0 8px 0;
-  color: #333;
+  color: var(--primary);
   font-size: 28px;
   font-weight: 600;
+  text-shadow: 0 0 15px rgba(254, 95, 0, 0.3);
 }
 
 .widget-manager-header p {
   margin: 0;
-  color: #666;
+  color: var(--muted);
   font-size: 16px;
 }
 
 .add-widget-btn {
-  background: #007bff;
-  color: white;
+  background: var(--primary);
+  color: #FFFFFF;
   border: none;
   padding: 12px 24px;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
 }
 
 .add-widget-btn:hover {
-  background: #0056b3;
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
+}
+
+.add-widget-btn:active {
+  text-shadow: -1px 0 var(--secondary), 1px 0 var(--accent);
 }
 
 /* Connection Status */
@@ -60,13 +67,13 @@
 
 .status-text h3 {
   margin: 0 0 8px 0;
-  color: #333;
+  color: var(--fg1);
   font-size: 24px;
 }
 
 .status-text p {
   margin: 0;
-  color: #666;
+  color: var(--muted);
   font-size: 16px;
 }
 
@@ -77,7 +84,7 @@
 
 .widget-section h3 {
   margin: 0 0 20px 0;
-  color: #333;
+  color: var(--primary);
   font-size: 20px;
   font-weight: 600;
 }
@@ -86,9 +93,9 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  background: #f8f9fa;
-  border-radius: 12px;
-  border: 2px dashed #dee2e6;
+  background: var(--bg1);
+  border-radius: var(--radius);
+  border: 2px dashed var(--border);
 }
 
 .empty-icon {
@@ -99,24 +106,26 @@
 
 .empty-state p {
   margin: 0 0 20px 0;
-  color: #666;
+  color: var(--muted);
   font-size: 16px;
 }
 
 .add-first-widget-btn {
-  background: #28a745;
-  color: white;
+  background: var(--primary);
+  color: #FFFFFF;
   border: none;
   padding: 12px 24px;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
 }
 
 .add-first-widget-btn:hover {
-  background: #1e7e34;
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
 }
 
 /* Widget Grid */
@@ -127,15 +136,16 @@
 }
 
 .widget-card {
-  background: white;
-  border: 1px solid #e0e0e0;
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 20px;
-  transition: box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .widget-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: var(--accent);
+  box-shadow: var(--glow-purple);
 }
 
 .widget-card-header {
@@ -147,7 +157,7 @@
 
 .widget-card-header h4 {
   margin: 0;
-  color: #333;
+  color: var(--fg1);
   font-size: 18px;
   font-weight: 600;
 }
@@ -166,14 +176,17 @@
   padding: 4px;
   border-radius: 4px;
   transition: background-color 0.2s ease;
+  color: var(--muted);
 }
 
 .config-btn:hover {
-  background: #f0f0f0;
+  background: var(--bg2);
+  color: var(--accent);
 }
 
 .remove-btn:hover {
-  background: #ffe6e6;
+  background: rgba(255, 46, 136, 0.15);
+  color: var(--secondary);
 }
 
 .widget-info {
@@ -181,12 +194,12 @@
   flex-direction: column;
   gap: 4px;
   font-size: 14px;
-  color: #666;
+  color: var(--muted);
 }
 
 .widget-size,
 .widget-position {
-  font-family: 'Monaco', 'Menlo', monospace;
+  font-family: 'JetBrains Mono', 'Menlo', monospace;
 }
 
 /* Modal Styles */
@@ -196,21 +209,23 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  backdrop-filter: blur(4px);
 }
 
 .modal {
-  background: white;
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   max-width: 600px;
   width: 90%;
   max-height: 80vh;
   overflow: hidden;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 40px 4px rgba(0, 0, 0, 0.6);
 }
 
 .modal-header {
@@ -218,14 +233,15 @@
   justify-content: space-between;
   align-items: center;
   padding: 20px 24px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border);
 }
 
 .modal-header h3 {
   margin: 0;
-  color: #333;
+  color: var(--primary);
   font-size: 20px;
   font-weight: 600;
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.3);
 }
 
 .close-btn {
@@ -233,14 +249,15 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: #666;
+  color: var(--muted);
   padding: 4px;
   border-radius: 4px;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .close-btn:hover {
-  background: #f0f0f0;
+  background: var(--bg2);
+  color: var(--fg1);
 }
 
 .modal-content {
@@ -261,25 +278,27 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  transition: border-color 0.2s ease;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg0);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .available-widget:hover {
-  border-color: #007bff;
+  border-color: var(--primary);
+  box-shadow: 0 0 12px 2px rgba(254, 95, 0, 0.3);
 }
 
 .available-widget .widget-info h4 {
   margin: 0 0 4px 0;
-  color: #333;
+  color: var(--fg1);
   font-size: 16px;
   font-weight: 600;
 }
 
 .available-widget .widget-info p {
   margin: 0 0 8px 0;
-  color: #666;
+  color: var(--muted);
   font-size: 14px;
 }
 
@@ -290,33 +309,35 @@
 }
 
 .widget-category {
-  background: #e9ecef;
-  color: #495057;
+  background: var(--gradient);
+  color: #FFFFFF;
   padding: 2px 8px;
   border-radius: 12px;
   font-weight: 500;
 }
 
 .widget-size {
-  color: #666;
-  font-family: 'Monaco', 'Menlo', monospace;
+  color: var(--muted);
+  font-family: 'JetBrains Mono', 'Menlo', monospace;
 }
 
 .add-btn {
-  background: #28a745;
-  color: white;
+  background: var(--primary);
+  color: #FFFFFF;
   border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
   white-space: nowrap;
+  font-family: inherit;
 }
 
 .add-btn:hover {
-  background: #1e7e34;
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
 }
 
 /* Configuration Form */
@@ -334,28 +355,33 @@
 
 .form-field label {
   font-weight: 500;
-  color: #333;
+  color: var(--muted);
   font-size: 14px;
 }
 
 .form-field input,
 .form-field select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   font-size: 14px;
-  transition: border-color 0.2s ease;
+  background: var(--bg0);
+  color: var(--fg1);
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .form-field input:focus,
 .form-field select:focus {
   outline: none;
-  border-color: #007bff;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4);
 }
 
 .form-field input[type="checkbox"] {
   width: auto;
   margin: 0;
+  accent-color: var(--primary);
 }
 
 .form-actions {
@@ -363,36 +389,38 @@
   justify-content: flex-end;
   gap: 12px;
   padding-top: 20px;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--border);
 }
 
 .form-actions button {
   padding: 10px 20px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
 }
 
 .form-actions button[type="button"] {
-  background: #6c757d;
-  color: white;
-  border: none;
+  background: var(--bg2);
+  color: var(--fg1);
+  border: 1px solid var(--border);
 }
 
 .form-actions button[type="button"]:hover {
-  background: #545b62;
+  background: var(--border);
 }
 
 .form-actions button[type="submit"] {
-  background: #007bff;
-  color: white;
+  background: var(--primary);
+  color: #FFFFFF;
   border: none;
 }
 
 .form-actions button[type="submit"]:hover {
-  background: #0056b3;
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
 }
 
 /* Responsive Design */

--- a/r1-control-panel/src/index.css
+++ b/r1-control-panel/src/index.css
@@ -1,29 +1,49 @@
 :root {
-  /* Gruvbox Dark Theme */
-  --bg0: #282828;
-  --bg1: #3c3836;
-  --bg2: #504945;
-  --bg3: #665c54;
-  --bg4: #7c6f64;
-  --fg0: #fbf1c7;
-  --fg1: #ebdbb2;
-  --fg2: #d5c4a1;
-  --fg3: #bdae93;
-  --fg4: #a89984;
-  --red: #fb4934;
-  --green: #b8bb26;
-  --yellow: #fabd2f;
-  --blue: #83a598;
-  --purple: #d3869b;
-  --aqua: #8ec07c;
-  --orange: #fe8019;
-  --red-dim: #cc241d;
-  --green-dim: #98971a;
-  --yellow-dim: #d79921;
-  --blue-dim: #458588;
-  --purple-dim: #b16286;
-  --aqua-dim: #689d6a;
-  --orange-dim: #d65d0e;
+  /* ===== Boondit Rhythm Design Tokens ===== */
+  /* Backgrounds */
+  --bg0: #111111;   /* base background */
+  --bg1: #1A1A1A;   /* cards */
+  --bg2: #292929;   /* muted bg */
+  --bg3: #292929;   /* borders */
+  --bg4: #292929;   /* muted bg alt */
+  /* Foreground */
+  --fg0: #FFFFFF;
+  --fg1: #FFFFFF;
+  --fg2: #D1D5DB;
+  --fg3: #9CA3AF;   /* muted text */
+  --fg4: #9CA3AF;   /* muted text alt */
+  /* Accent colors (Gruvbox names remapped to rhythm palette) */
+  --red: #FF2E88;       /* secondary - hot pink */
+  --green: #3FB950;     /* success (kept readable on dark) */
+  --yellow: #FE5F00;    /* primary - orange-red */
+  --blue: #9B2EFF;      /* accent - purple */
+  --purple: #9B2EFF;    /* accent - purple */
+  --aqua: #9B2EFF;      /* accent - purple */
+  --orange: #FE5F00;    /* primary - orange-red */
+  /* Dimmed variants for gradients/hover */
+  --red-dim: #E0247A;
+  --green-dim: #2DA44E;
+  --yellow-dim: #D95000;
+  --blue-dim: #7C28D1;
+  --purple-dim: #7C28D1;
+  --aqua-dim: #7C28D1;
+  --orange-dim: #D95000;
+
+  /* Rhythm semantic tokens */
+  --primary: #FE5F00;
+  --secondary: #FF2E88;
+  --accent: #9B2EFF;
+  --card: #1A1A1A;
+  --border: #292929;
+  --muted: #9CA3AF;
+  --bg: #111111;
+  --radius: 0.5rem;
+  --radius-sm: 6px;
+  --gradient: linear-gradient(90deg, #FF1F8F 0%, #A864FF 100%);
+  --gradient-diag: linear-gradient(135deg, #FF1F8F 0%, #A864FF 100%);
+  --glow: 0 0 12px 2px rgba(254, 95, 0, 0.6);
+  --glow-pink: 0 0 12px 2px rgba(255, 46, 136, 0.5);
+  --glow-purple: 0 0 12px 2px rgba(155, 46, 255, 0.5);
 }
 
 * {
@@ -33,7 +53,8 @@
 }
 
 body {
-  font-family: 'JetBrains Mono', 'Fira Code', 'Monaco', monospace;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg0);
@@ -41,10 +62,10 @@ body {
   color: var(--fg1);
 }
 
-/* Global overrides to ensure Gruvbox theme everywhere */
+/* Global overrides to ensure rhythm theme everywhere */
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--bg4) var(--bg1);
+  scrollbar-color: var(--border) var(--bg1);
 }
 
 /* Override any white backgrounds */
@@ -73,7 +94,7 @@ h6 {
 }
 
 code {
-  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-family: 'JetBrains Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
 }
 
 .container {
@@ -84,63 +105,76 @@ code {
 
 .card {
   background: var(--bg1);
-  border: 1px solid var(--bg3);
-  border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02);
   padding: 20px;
   margin-bottom: 20px;
 }
 
 .btn {
-  background: var(--blue);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   border: none;
   padding: 10px 20px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 14px;
   font-weight: 600;
-  transition: all 0.2s;
+  transition: filter 0.15s ease, box-shadow 0.15s ease, transform 0.05s ease;
   font-family: inherit;
 }
 
 .btn:hover {
-  background: var(--blue-dim);
-  transform: translateY(-1px);
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
+}
+
+.btn:active {
+  transform: translateY(0);
+  text-shadow: -1px 0 var(--secondary), 1px 0 var(--accent);
 }
 
 .btn:disabled {
-  background: var(--bg4);
-  color: var(--fg4);
+  background: var(--border);
+  color: var(--muted);
   cursor: not-allowed;
-  transform: none;
+  filter: none;
+  box-shadow: none;
 }
 
 .btn-secondary {
-  background: var(--bg3);
+  background: transparent;
   color: var(--fg1);
+  border: 1px solid var(--border);
 }
 
 .btn-secondary:hover {
-  background: var(--bg4);
+  background: var(--bg1);
+  filter: none;
+  box-shadow: none;
 }
 
 .btn-success {
   background: var(--green);
-  color: var(--bg0);
+  color: #FFFFFF;
 }
 
 .btn-success:hover {
   background: var(--green-dim);
+  filter: none;
+  box-shadow: 0 0 12px 2px rgba(63, 185, 80, 0.5);
 }
 
 .btn-danger {
-  background: var(--red);
-  color: var(--fg0);
+  background: var(--secondary);
+  color: #FFFFFF;
 }
 
 .btn-danger:hover {
   background: var(--red-dim);
+  filter: none;
+  box-shadow: var(--glow-pink);
 }
 
 .btn-sm {
@@ -156,7 +190,7 @@ code {
   display: block;
   margin-bottom: 5px;
   font-weight: 600;
-  color: var(--aqua);
+  color: var(--muted);
 }
 
 .form-input,
@@ -164,21 +198,21 @@ code {
 .form-textarea {
   width: 100%;
   padding: 10px;
-  border: 1px solid var(--bg3);
-  border-radius: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
   font-size: 14px;
-  background: var(--bg0);
+  background: var(--bg1);
   color: var(--fg1);
   font-family: inherit;
-  transition: border-color 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .form-input:focus,
 .form-select:focus,
 .form-textarea:focus {
   outline: none;
-  border-color: var(--yellow);
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4);
 }
 
 .form-textarea {
@@ -195,15 +229,15 @@ code {
 }
 
 .status-running {
-  background: #28a745;
+  background: var(--green);
 }
 
 .status-stopped {
-  background: #dc3545;
+  background: var(--secondary);
 }
 
 .status-disabled {
-  background: #6c757d;
+  background: var(--muted);
 }
 
 .modal-overlay {
@@ -221,19 +255,19 @@ code {
 }
 
 .modal-content {
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 25px;
   width: 90%;
   max-width: 600px;
   max-height: 80vh;
   overflow-y: auto;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 0 40px 4px rgba(0, 0, 0, 0.6);
   color: var(--fg1);
 }
 
-/* Ensure all modal children use Gruvbox colors */
+/* Ensure all modal children use rhythm colors */
 .modal-content * {
   color: inherit;
 }
@@ -243,14 +277,14 @@ code {
 .modal-content select {
   background: var(--bg0) !important;
   color: var(--fg1) !important;
-  border: 1px solid var(--bg3) !important;
+  border: 1px solid var(--border) !important;
 }
 
 .modal-content input:focus,
 .modal-content textarea:focus,
 .modal-content select:focus {
-  border-color: var(--yellow) !important;
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2) !important;
+  border-color: var(--primary) !important;
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4) !important;
 }
 
 .modal-content::-webkit-scrollbar {
@@ -263,7 +297,7 @@ code {
 }
 
 .modal-content::-webkit-scrollbar-thumb {
-  background: var(--bg4);
+  background: var(--border);
   border-radius: 4px;
 }
 
@@ -273,22 +307,22 @@ code {
   align-items: center;
   margin-bottom: 25px;
   padding-bottom: 18px;
-  border-bottom: 2px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
 }
 
 .modal-title {
   font-size: 20px;
   font-weight: bold;
-  color: var(--yellow);
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  color: var(--primary);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.4);
 }
 
 .modal-close {
-  background: var(--red);
+  background: var(--secondary);
   border: none;
   font-size: 18px;
   cursor: pointer;
-  color: var(--fg0);
+  color: #FFFFFF;
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -302,6 +336,7 @@ code {
 .modal-close:hover {
   background: var(--red-dim);
   transform: scale(1.1);
+  box-shadow: var(--glow-pink);
 }
 
 .grid {
@@ -322,19 +357,19 @@ code {
 }
 
 .text-muted {
-  color: #666;
+  color: var(--muted);
 }
 
 .text-success {
-  color: #28a745;
+  color: var(--green);
 }
 
 .text-danger {
-  color: #dc3545;
+  color: var(--secondary);
 }
 
 .text-warning {
-  color: #ffc107;
+  color: var(--primary);
 }
 
 .mb-0 {
@@ -373,8 +408,8 @@ code {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border: 2px solid #f3f3f3;
-  border-top: 2px solid #667eea;
+  border: 2px solid var(--border);
+  border-top: 2px solid var(--primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin-right: 8px;
@@ -397,17 +432,17 @@ code {
   align-items: center;
   justify-content: center;
   padding: 20px;
-  background: linear-gradient(135deg, var(--bg0) 0%, var(--bg1) 100%);
+  background: var(--bg0);
 }
 
 .login-card {
   background: var(--bg1);
-  border: 1px solid var(--bg3);
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 40px;
   width: 100%;
   max-width: 500px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 40px 4px rgba(0, 0, 0, 0.5);
 }
 
 .login-header {
@@ -416,14 +451,14 @@ code {
 }
 
 .login-header h1 {
-  color: var(--yellow);
+  color: var(--primary);
   font-size: 2.5em;
   margin-bottom: 10px;
-  text-shadow: 0 0 20px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 20px rgba(254, 95, 0, 0.4);
 }
 
 .login-header p {
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 1.1em;
 }
 
@@ -433,33 +468,34 @@ code {
 
 .form-help {
   font-size: 12px;
-  color: var(--fg4);
+  color: var(--muted);
   margin-top: 5px;
 }
 
 .error-message {
-  background: var(--red-dim);
-  color: var(--fg0);
+  background: rgba(255, 46, 136, 0.12);
+  color: var(--secondary);
   padding: 12px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   margin-bottom: 20px;
-  border-left: 4px solid var(--red);
+  border-left: 4px solid var(--secondary);
 }
 
 .login-btn {
   width: 100%;
   padding: 15px;
   font-size: 16px;
-  background: var(--green);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
 }
 
 .login-btn:hover {
-  background: var(--green-dim);
+  filter: brightness(1.1);
+  box-shadow: var(--glow);
 }
 
 .login-footer {
-  border-top: 1px solid var(--bg3);
+  border-top: 1px solid var(--border);
   padding-top: 20px;
 }
 
@@ -470,7 +506,7 @@ code {
 
 .security-note h4,
 .help-section h4 {
-  color: var(--aqua);
+  color: var(--accent);
   margin-bottom: 10px;
   font-size: 14px;
 }
@@ -482,7 +518,7 @@ code {
 
 .security-note li {
   font-size: 12px;
-  color: var(--fg3);
+  color: var(--muted);
   margin-bottom: 5px;
   padding-left: 15px;
   position: relative;
@@ -498,40 +534,58 @@ code {
 
 .help-section p {
   font-size: 12px;
-  color: var(--fg3);
+  color: var(--muted);
   line-height: 1.4;
 }
 
 /* Device Header */
 .device-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 20px;
   background: var(--bg1);
-  border: 1px solid var(--bg3);
-  border-radius: 8px;
-  margin-bottom: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 23px;
+}
+
+/* Brand stripe - 3-segment ribbon under the device header */
+.device-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -3px;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    #FF1F8F 0%, #FF1F8F 33.33%,
+    #A864FF 33.33%, #A864FF 66.66%,
+    #1F4A3F 66.66%, #1F4A3F 100%
+  );
+  border-radius: 0 0 var(--radius) var(--radius);
 }
 
 .device-info h1 {
-  color: var(--yellow);
+  color: var(--primary);
   margin: 0 0 5px 0;
   font-size: 1.8em;
 }
 
 .device-id {
-  color: var(--aqua);
+  color: var(--accent);
   font-size: 14px;
-  font-family: 'Monaco', monospace;
+  font-family: 'JetBrains Mono', 'Monaco', monospace;
 }
 
 .logout-btn {
-  background: var(--red);
-  color: var(--fg0);
+  background: var(--secondary);
+  color: #FFFFFF;
   border: none;
   padding: 8px 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
@@ -540,24 +594,26 @@ code {
 
 .logout-btn:hover {
   background: var(--red-dim);
+  box-shadow: var(--glow-pink);
 }
 
 /* Tab Navigation */
 .tab-nav {
   display: flex;
   gap: 4px;
-  background: var(--bg2);
-  border-radius: 8px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 4px;
 }
 
 .tab-btn {
   flex: 1;
   background: transparent;
-  color: var(--fg3);
+  color: var(--muted);
   border: none;
   padding: 12px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -566,18 +622,19 @@ code {
 }
 
 .tab-btn:hover {
-  background: var(--bg3);
+  background: var(--bg2);
   color: var(--fg1);
 }
 
 .tab-btn.active {
-  background: var(--blue);
-  color: var(--bg0);
+  background: var(--gradient);
+  color: #FFFFFF;
   font-weight: 600;
+  box-shadow: var(--glow-purple);
 }
 
 .tab-btn.active:hover {
-  background: var(--blue-dim);
+  filter: brightness(1.05);
 }
 
 /* Chat Styles */
@@ -587,26 +644,26 @@ code {
   align-items: center;
   margin-bottom: 20px;
   padding-bottom: 15px;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
 }
 
 .chat-header h2 {
-  color: var(--yellow);
+  color: var(--primary);
   margin: 0;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.4);
 }
 
 .chat-messages {
   background: var(--bg0);
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   height: 400px;
   overflow-y: auto;
   margin-bottom: 15px;
   font-family: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
   font-size: 13px;
-  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .chat-messages::-webkit-scrollbar {
@@ -619,52 +676,52 @@ code {
 }
 
 .chat-messages::-webkit-scrollbar-thumb {
-  background: var(--bg4);
+  background: var(--border);
   border-radius: 4px;
 }
 
 .chat-messages::-webkit-scrollbar-thumb:hover {
-  background: var(--fg4);
+  background: var(--muted);
 }
 
 .message {
   margin: 12px 0;
   padding: 12px 16px;
-  border-radius: 8px;
-  border-left: 4px solid var(--blue);
+  border-radius: var(--radius);
+  border-left: 4px solid var(--accent);
   background: var(--bg1);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .message.user {
-  background: rgba(131, 165, 152, 0.15);
-  border-left-color: var(--aqua);
+  background: rgba(155, 46, 255, 0.12);
+  border-left-color: var(--accent);
   border-left-width: 4px;
 }
 
 .message.assistant {
-  background: rgba(211, 134, 155, 0.15);
-  border-left-color: var(--purple);
+  background: rgba(255, 31, 143, 0.12);
+  border-left-color: var(--secondary);
   border-left-width: 4px;
 }
 
 .message.system {
-  background: rgba(250, 189, 47, 0.15);
-  border-left-color: var(--yellow);
+  background: rgba(254, 95, 0, 0.12);
+  border-left-color: var(--primary);
   border-left-width: 4px;
   font-style: italic;
 }
 
 .message.error {
-  background: rgba(251, 73, 52, 0.15);
-  border-left-color: var(--red);
+  background: rgba(255, 46, 136, 0.12);
+  border-left-color: var(--secondary);
   border-left-width: 4px;
 }
 
 .message-header {
   font-weight: bold;
   font-size: 11px;
-  color: var(--fg4);
+  color: var(--muted);
   margin-bottom: 6px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -682,44 +739,45 @@ code {
   align-items: flex-end;
   padding: 15px;
   background: var(--bg1);
-  border-radius: 8px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .chat-input-area .form-textarea {
   flex: 1;
   background: var(--bg0);
-  border: 2px solid var(--bg3);
+  border: 1px solid var(--border);
   color: var(--fg1);
   resize: vertical;
   min-height: 60px;
 }
 
 .chat-input-area .form-textarea:focus {
-  border-color: var(--yellow);
-  box-shadow: 0 0 0 3px rgba(250, 189, 47, 0.2);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.4);
 }
 
 .chat-input-area .btn {
   min-width: 100px;
-  background: var(--green);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .chat-input-area .btn:hover {
-  background: var(--green-dim);
+  filter: brightness(1.1);
   transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--glow);
 }
 
 .chat-input-area .btn:disabled {
-  background: var(--bg4);
-  color: var(--fg4);
+  background: var(--border);
+  color: var(--muted);
   transform: none;
   box-shadow: none;
+  filter: none;
 }
 
 /* MCP Styles */
@@ -729,21 +787,21 @@ code {
   align-items: flex-start;
   margin-bottom: 25px;
   padding: 20px;
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  border: 1px solid var(--bg3);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .mcp-header h2 {
-  color: var(--yellow);
+  color: var(--primary);
   margin: 0 0 8px 0;
-  text-shadow: 0 0 15px rgba(250, 189, 47, 0.4);
+  text-shadow: 0 0 15px rgba(254, 95, 0, 0.4);
   font-size: 1.8em;
 }
 
 .mcp-header p {
-  color: var(--fg3);
+  color: var(--muted);
   margin: 0;
   font-size: 14px;
   font-style: italic;
@@ -756,52 +814,55 @@ code {
 }
 
 .mcp-actions .btn {
-  background: var(--blue);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .mcp-actions .btn:hover {
-  background: var(--blue-dim);
+  filter: brightness(1.1);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--glow);
 }
 
 .mcp-actions .btn-secondary {
-  background: var(--bg3);
+  background: transparent;
   color: var(--fg1);
+  border: 1px solid var(--border);
 }
 
 .mcp-actions .btn-secondary:hover {
-  background: var(--bg4);
+  background: var(--bg1);
+  filter: none;
+  box-shadow: none;
 }
 
 .loading-container {
   text-align: center;
   padding: 60px;
-  color: var(--fg3);
+  color: var(--muted);
   background: var(--bg1);
-  border-radius: 8px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
 }
 
 .empty-state {
   text-align: center;
   padding: 80px 30px;
-  color: var(--fg3);
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  border-radius: 12px;
-  border: 2px dashed var(--bg3);
+  color: var(--muted);
+  background: var(--bg1);
+  border-radius: var(--radius);
+  border: 2px dashed var(--border);
 }
 
 .empty-state h3 {
-  color: var(--yellow);
+  color: var(--primary);
   margin-bottom: 15px;
   font-size: 1.5em;
-  text-shadow: 0 0 10px rgba(250, 189, 47, 0.3);
+  text-shadow: 0 0 12px rgba(254, 95, 0, 0.4);
 }
 
 .empty-state p {
@@ -811,20 +872,20 @@ code {
 }
 
 .empty-state .btn {
-  background: var(--green);
-  color: var(--bg0);
+  background: var(--primary);
+  color: #FFFFFF;
   font-size: 16px;
   padding: 12px 24px;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
 }
 
 .empty-state .btn:hover {
-  background: var(--green-dim);
+  filter: brightness(1.1);
   transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--glow);
 }
 
 .mcp-grid {
@@ -834,27 +895,27 @@ code {
 }
 
 .mcp-server-card {
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  border: 2px solid var(--bg3);
-  border-radius: 12px;
+  background: var(--bg1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 25px;
   border-left: 6px solid var(--green);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02);
   transition: all 0.3s ease;
 }
 
 .mcp-server-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
-  border-color: var(--bg4);
+  box-shadow: var(--glow);
+  border-color: var(--accent);
 }
 
 .mcp-server-card.stopped {
-  border-left-color: var(--red);
+  border-left-color: var(--secondary);
 }
 
 .mcp-server-card.disabled {
-  border-left-color: var(--bg4);
+  border-left-color: var(--border);
   opacity: 0.7;
 }
 
@@ -864,14 +925,14 @@ code {
   align-items: center;
   margin-bottom: 18px;
   padding-bottom: 12px;
-  border-bottom: 1px solid var(--bg3);
+  border-bottom: 1px solid var(--border);
 }
 
 .mcp-server-name {
   font-weight: bold;
   font-size: 1.3em;
   color: var(--fg0);
-  text-shadow: 0 0 8px rgba(251, 241, 199, 0.3);
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.15);
 }
 
 .device-status {
@@ -884,24 +945,24 @@ code {
   align-items: center;
   gap: 8px;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .device-status.running {
   background: linear-gradient(135deg, var(--green-dim), var(--green));
-  color: var(--bg0);
-  box-shadow: 0 0 12px rgba(184, 187, 38, 0.4);
+  color: #FFFFFF;
+  box-shadow: 0 0 12px rgba(63, 185, 80, 0.45);
 }
 
 .device-status.stopped {
-  background: linear-gradient(135deg, var(--red-dim), var(--red));
-  color: var(--fg0);
-  box-shadow: 0 0 12px rgba(251, 73, 52, 0.4);
+  background: linear-gradient(135deg, var(--red-dim), var(--secondary));
+  color: #FFFFFF;
+  box-shadow: 0 0 12px rgba(255, 46, 136, 0.45);
 }
 
 .device-status.disabled {
-  background: linear-gradient(135deg, var(--bg3), var(--bg4));
-  color: var(--fg4);
+  background: linear-gradient(135deg, var(--border), var(--bg2));
+  color: var(--muted);
 }
 
 .status-indicator {
@@ -934,7 +995,7 @@ code {
 }
 
 .status-disabled {
-  background: var(--fg4);
+  background: var(--muted);
 }
 
 .mcp-server-description {
@@ -953,8 +1014,8 @@ code {
   font-size: 0.9em;
   background: var(--bg0);
   padding: 15px;
-  border-radius: 6px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
 }
 
 .mcp-server-detail {
@@ -965,13 +1026,12 @@ code {
 
 .mcp-server-detail-label {
   font-weight: bold;
-  color: var(--aqua);
-  text-shadow: 0 0 5px rgba(142, 192, 124, 0.3);
+  color: var(--accent);
 }
 
 .mcp-server-detail span:last-child {
   color: var(--fg1);
-  font-family: 'Monaco', monospace;
+  font-family: 'JetBrains Mono', 'Monaco', monospace;
 }
 
 .mcp-server-actions {
@@ -987,32 +1047,31 @@ code {
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.3px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .mcp-server-actions .btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--glow);
 }
 
 .mcp-tools-list {
   margin-top: 20px;
   padding-top: 18px;
-  border-top: 2px solid var(--bg3);
+  border-top: 2px solid var(--border);
   background: var(--bg0);
   padding: 15px;
-  border-radius: 6px;
-  border: 1px solid var(--bg3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
 }
 
 .mcp-tools-header {
   font-size: 0.9em;
   font-weight: bold;
   margin-bottom: 12px;
-  color: var(--aqua);
+  color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  text-shadow: 0 0 8px rgba(142, 192, 124, 0.3);
 }
 
 .mcp-tool-item {
@@ -1021,7 +1080,7 @@ code {
   align-items: center;
   padding: 8px 0;
   font-size: 0.8em;
-  border-bottom: 1px solid var(--bg2);
+  border-bottom: 1px solid var(--border);
 }
 
 .mcp-tool-item:last-child {
@@ -1031,11 +1090,11 @@ code {
 .mcp-tool-name {
   font-weight: bold;
   color: var(--fg1);
-  font-family: 'Monaco', monospace;
+  font-family: 'JetBrains Mono', 'Monaco', monospace;
 }
 
 .mcp-tool-usage {
-  color: var(--fg4);
+  color: var(--muted);
   font-style: italic;
 }
 
@@ -1048,26 +1107,26 @@ code {
 }
 
 .template-card {
-  border: 2px solid var(--bg3);
-  border-radius: 10px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
   padding: 18px;
   cursor: pointer;
   transition: all 0.3s ease;
   background: var(--bg0);
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .template-card:hover {
-  border-color: var(--blue);
+  border-color: var(--accent);
   background: var(--bg1);
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--glow-purple);
 }
 
 .template-card.selected {
-  border-color: var(--yellow);
-  background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 100%);
-  box-shadow: 0 0 20px rgba(250, 189, 47, 0.3);
+  border-color: var(--primary);
+  background: var(--bg1);
+  box-shadow: 0 0 0 2px rgba(254, 95, 0, 0.3), var(--glow);
 }
 
 .template-name {
@@ -1078,7 +1137,7 @@ code {
 }
 
 .template-description {
-  color: var(--fg3);
+  color: var(--muted);
   font-size: 0.9em;
   line-height: 1.4;
   margin-bottom: 12px;
@@ -1086,8 +1145,8 @@ code {
 
 .template-category {
   display: inline-block;
-  background: linear-gradient(135deg, var(--blue-dim), var(--blue));
-  color: var(--bg0);
+  background: var(--gradient);
+  color: #FFFFFF;
   padding: 4px 12px;
   border-radius: 15px;
   font-size: 0.7em;
@@ -1095,19 +1154,19 @@ code {
   text-transform: uppercase;
   margin-top: 8px;
   letter-spacing: 0.5px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .template-category-system {
-  background: linear-gradient(135deg, var(--orange-dim), var(--orange));
+  background: linear-gradient(135deg, var(--orange-dim), var(--primary));
 }
 
 .template-category-web {
-  background: linear-gradient(135deg, var(--blue-dim), var(--blue));
+  background: var(--gradient);
 }
 
 .template-category-development {
-  background: linear-gradient(135deg, var(--purple-dim), var(--purple));
+  background: linear-gradient(135deg, var(--purple-dim), var(--accent));
 }
 
 .template-category-database {
@@ -1115,22 +1174,22 @@ code {
 }
 
 .template-category-cloud {
-  background: linear-gradient(135deg, var(--aqua-dim), var(--aqua));
+  background: var(--gradient-diag);
 }
 
 /* Logs Modal Styles */
 .logs-container {
   background: var(--bg0);
   color: var(--fg1);
-  border: 2px solid var(--bg3);
-  border-radius: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 15px;
   height: 300px;
   overflow-y: auto;
   font-family: 'JetBrains Mono', 'Monaco', 'Menlo', monospace;
   font-size: 12px;
   line-height: 1.4;
-  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .logs-container::-webkit-scrollbar {
@@ -1143,7 +1202,7 @@ code {
 }
 
 .logs-container::-webkit-scrollbar-thumb {
-  background: var(--bg4);
+  background: var(--border);
   border-radius: 4px;
 }
 
@@ -1155,31 +1214,31 @@ code {
 }
 
 .log-entry.info {
-  background: rgba(131, 165, 152, 0.1);
-  border-left-color: var(--blue);
-  color: var(--blue);
+  background: rgba(155, 46, 255, 0.1);
+  border-left-color: var(--accent);
+  color: var(--accent);
 }
 
 .log-entry.warn {
-  background: rgba(250, 189, 47, 0.1);
-  border-left-color: var(--yellow);
-  color: var(--yellow);
+  background: rgba(254, 95, 0, 0.1);
+  border-left-color: var(--primary);
+  color: var(--primary);
 }
 
 .log-entry.error {
-  background: rgba(251, 73, 52, 0.1);
-  border-left-color: var(--red);
-  color: var(--red);
+  background: rgba(255, 46, 136, 0.1);
+  border-left-color: var(--secondary);
+  color: var(--secondary);
 }
 
 .log-entry.debug {
-  background: rgba(168, 153, 132, 0.1);
-  border-left-color: var(--fg4);
-  color: var(--fg4);
+  background: rgba(156, 163, 175, 0.1);
+  border-left-color: var(--muted);
+  color: var(--muted);
 }
 
 .log-timestamp {
-  color: var(--fg4);
+  color: var(--muted);
   margin-right: 8px;
 }
 
@@ -1189,7 +1248,7 @@ code {
 }
 
 .log-server {
-  color: var(--aqua);
+  color: var(--accent);
   margin-right: 8px;
   font-weight: bold;
 }


### PR DESCRIPTION
Both frontends (r1-control-panel + creation-react) redesigned to match boondit-rhythm visual identity. Gruvbox palette replaced with rhythm dark tokens (bg #111, primary #FE5F00, secondary #FF2E88, accent #9B2EFF). Glow shadows, gradient accents, 3px brand stripe. 16 files changed, 922 insertions, 757 deletions. Both builds pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brand stripe visual element to console and dashboard interfaces

* **Style**
  * Updated theme from Gruvbox to Boondit Rhythm dark theme
  * Refreshed color palette with new accent and status indicator colors
  * Enhanced typography with improved system fonts and visual effects
  * Improved styling for buttons, components, and interactive elements throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->